### PR TITLE
Fixed undefined show titles

### DIFF
--- a/app/js/viewer/ApplicationController.js
+++ b/app/js/viewer/ApplicationController.js
@@ -56,7 +56,11 @@ ApplicationController.prototype.setShow = function (show) {
  * this._show has already been loaded.
  */
 ApplicationController.prototype._updateUIWithShow = function () {
-    $(".js-show-title").text(this._show.getTitle());
+    if (typeof this._show.getTitle() === "undefined") {
+        $(".js-show-title").text("Untitled Show");
+    } else {
+        $(".js-show-title").text(this._show.getTitle());
+    }
     var options = this._show.getDotLabels().map(function (value) {
         return "<option value='" + value + "'>" + value + "</option>";
     });


### PR DESCRIPTION
The P!nk show doesn't have a title defined, and it still showed "No Show Selected" as the title of the show. I changed it to read "Untitled Show" instead, if there is no title defined.
