### PR TITLE
Limit height of dropdown

### DIFF
--- a/css/app.less
+++ b/css/app.less
@@ -122,6 +122,9 @@
                     display: block;
                     margin: 20px 0 10px;
                 }
+                .chosen-drop .chosen-results {
+                    max-height: 100px;
+                }
             }
         }
     }


### PR DESCRIPTION
This should make the autoload more manageable in terms of size (when we have 8 shows on there, we don't want the whole list showing). The most recent show should also appear on the top with the pull request in the calchart-server repository.
