### PR TITLE
Remove redundant ternary operator

### DIFF
--- a/js/pdf/MovementDiagramWidget.js
+++ b/js/pdf/MovementDiagramWidget.js
@@ -16,7 +16,7 @@ var PDFWidget = require("./PDFWidget");
  * @param {String} orientation, the direction on the top of the box
  */
 var MovementDiagramWidget = function(pdf, orientation) {
-    this.westUp = (orientation === "west") ? true : false;
+    this.westUp = orientation == "west";
     PDFWidget.apply(this, [pdf]);
 };
 


### PR DESCRIPTION
Ternary ifs may be redundant when the expected return value is also a boolean. Not sure about benefits of strict string comparison here.