### PR TITLE
Remove ogg alert

### DIFF
--- a/js/application.js
+++ b/js/application.js
@@ -88,13 +88,6 @@ $(document).ready(function () {
             window.location.search = "show=" + $(this).val();
         });
 
-    // Detect browser from http://stackoverflow.com/questions/5899783/detect-safari-using-jquery
-    var browserString = navigator.userAgent;
-    var isSafari = (browserString.indexOf("Safari") > -1) && (browserString.indexOf("Chrome") == -1);
-    if (isSafari) {
-        alert("You may not be able to upload .ogg files using Safari. Either use an mp3 version of the file or use the Viewer on another browser.")
-    }
-
     applicationController.getShows().complete(function() {
         // URL options
         var options = JSUtils.getAllURLParams();


### PR DESCRIPTION
After finding that AAC format works pretty well per the discussion in #112, removing alert from Safari if Stunt moves towards AAC.

@noahsark769 @rmpowell77 @kmdurand is everyone satisfied with the discussion in 112?