### PR TITLE
Add yardlines to surrounding dots widget

### DIFF
--- a/css/pdf.less
+++ b/css/pdf.less
@@ -32,6 +32,7 @@ body {
     }
     h3 {
         margin-bottom: 5px;
+        white-space: normal;
     }
     p {
         margin: 0;
@@ -91,6 +92,9 @@ body {
         &.error {
             color: #ff0000;
         }
+    }
+    p {
+        margin-bottom: 10px;
     }
     .progress-bar-container {
         width: 400px;

--- a/js/pdf.js
+++ b/js/pdf.js
@@ -52,6 +52,10 @@ function removeIFrame() {
     $("<p>")
         .append(link)
         .appendTo(".js-pdf-loading");
+        
+    $("<p>")
+        .text("Are you on Google Chrome? Try opening the PDF outside of Chrome.")
+        .appendTo(".js-pdf-loading");
 };
 
 /**

--- a/js/pdf/PDFUtils.js
+++ b/js/pdf/PDFUtils.js
@@ -172,6 +172,30 @@ PDFUtils.getYCoordinateText = function(y) {
         this.setLineWidth(.3);
         return this;
     };
+
+    /**
+     * This jsPDF plugin draws a horizontal line from the given (x,y) coordinate to
+     * the coordinate (x + width, y)
+     *
+     * @param {float} x
+     * @param {float} y
+     * @param {float} width
+     */
+    jsPDFAPI.hLine = function(x, y, width) {
+        this.line(x, y, x + width, y);
+    };
+
+    /**
+     * This jsPDF plugin draws a vertical line from the given (x,y) coordinate to
+     * the coordinate (x, y + height)
+     *
+     * @param {float} x
+     * @param {float} y
+     * @param {float} height
+     */
+    jsPDFAPI.vLine = function(x, y, height) {
+        this.line(x, y, x, y + height);
+    };
 })(jsPDF.API);
 
 module.exports = PDFUtils;

--- a/js/pdf/SurroundingDotsWidget.js
+++ b/js/pdf/SurroundingDotsWidget.js
@@ -57,22 +57,26 @@ SurroundingDotsWidget.prototype.draw = function(x, y, width, height, options) {
         x: box.x + box.width/2,
         y: box.y + box.height/2
     };
-
-    this.pdf.setDrawColor(150);
-    this.pdf.setLineWidth(.1);
-    // cross hairs for selected dot
-    this.pdf.line(
-        origin.x, box.y,
-        origin.x, box.y + box.height
-    );
-    this.pdf.line(
-        box.x, origin.y,
-        box.x + box.width, origin.y
-    );
-
     var sheet = options["sheet"];
     var start = options["dot"].getAnimationState(0);
     var orientationFactor = this.westUp ? 1 : -1;
+    var scale = box.height / 11.5; // radius of 4 steps + 1.75 steps of padding
+
+    // yardlines
+    this.pdf.setDrawColor(150);
+    this.pdf.setLineWidth(.1);
+    // # of steps north of the yardline the dot is at
+    var yardlineDelta = start.x % 8;
+    if (yardlineDelta > 4) {
+        yardlineDelta = 4 - yardlineDelta;
+    }
+    var yardlineX = origin.x - yardlineDelta * scale * orientationFactor;
+    this.pdf.vLine(yardlineX, box.y, box.height);
+    // the only time 2 yardlines will be drawn is if the dot is splitting
+    if (Math.abs(yardlineDelta) === 4) {
+        yardlineX = origin.x + yardlineDelta * scale * orientationFactor;
+        this.pdf.vLine(yardlineX, box.y, box.height);
+    }
 
     var allDots = sheet.getDots();
     var surroundingDots = [];
@@ -91,7 +95,6 @@ SurroundingDotsWidget.prototype.draw = function(x, y, width, height, options) {
         }
     });
 
-    var scale = box.height / 11.5; // radius of 4 steps + 1.75 steps of padding
     var labelSize = box.height * 7/29;
     var dotRadius = box.height * .04;
     this.pdf.setFontSize(labelSize);


### PR DESCRIPTION
Requested by STUNT. Also fixed bug in Firefox hiding the "Select all" link and added a help text for Chrome users

Should also make an issue to convert all calls of `.line()` to `.vLine()` or `.hLine()`, if applicable