### PR TITLE
Improve show-load diagnostics and log build metadata

### DIFF
--- a/js/application.js
+++ b/js/application.js
@@ -37,6 +37,19 @@ var onLongPress = function(selector, callback) {
  * @todo: implement the Calchart Viewer app here
  */
 $(document).ready(function () {
+    $.getJSON("build/build-info.json")
+        .done(function(buildInfo) {
+            console.log(
+                "[Calchart Viewer] Build info:",
+                buildInfo.branch + "@" + buildInfo.commit,
+                "built",
+                buildInfo.builtAt
+            );
+        })
+        .fail(function() {
+            console.log("[Calchart Viewer] Build info unavailable.");
+        });
+
     var applicationController = ApplicationController.getInstance();
     applicationController.init();
 


### PR DESCRIPTION
Add explicit console error logging for viewer/beats/autoload failures Show fallback UI errors when unknown load exceptions occur Wrap autoload parsing in try/catch so failures are visible instead of silent Add build-info grunt task to emit commit/branch/timestamp metadata Log build metadata on app startup for easier deployed-version verification